### PR TITLE
feat: prohibit admins from deleting their own account

### DIFF
--- a/source/fsicalmanagement/fsicalmanagement.d
+++ b/source/fsicalmanagement/fsicalmanagement.d
@@ -86,15 +86,16 @@ public:
         redirect("/");
     }
 
-    @auth(Role.admin) void getUsers()
+    @auth(Role.admin) void getUsers(string _error = null)
     {
         auto users = authenticator.getAllUsers;
         auto authInfo = this.authInfo.value;
-        render!("showusers.dt", users, authInfo);
+        render!("showusers.dt", _error, users, authInfo);
     }
 
-    @auth(Role.admin) void postRemoveuser(string id)
+    @auth(Role.admin) @errorDisplay!getUsers void postRemoveuser(string id)
     {
+        enforce(id != authInfo.value.id, "Du kannst deinen eigenen Account nicht löschen.");
         authenticator.removeUser(id);
         redirect("/users");
     }

--- a/views/showusers.dt
+++ b/views/showusers.dt
@@ -16,3 +16,5 @@ block content
 			input#id(value="#{user.id}", name="id", type="hidden")
 			input#submitButton(type="submit", value="Entfernen")
 		hr
+	- if (_error)
+		p.error= _error


### PR DESCRIPTION
As mentioned in #6 , this implements functionality to prohibt admins from deleting their account. This results in there being at least one admin account.

This includes the following changes:
 - Prohibit admins from deleting their account.
 - Redirect them to the user list and siplay an error message, if they try to do it.

fixes #6.