### PR TITLE
fix: fix building on OS X

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -29,8 +29,5 @@
 				"unit-threaded": "~>0.7.31"
 			}
 		}
-	],
-	"lflags": [
-		"-fuse-ld=gold"
 	]
 }


### PR DESCRIPTION
As mentioned in #19, this fixes building on OS X.

This includes the following changes:
 - remvoes the `-fuse-ld=gold` flag in `dub.json`

