### PR TITLE
chore: make OpenSSL-1.1 the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ addons:
       - libssl-dev
 
 script:
-- dub build
-- dub test
+- dub build --override-config vibe-d:tls/openssl
+- dub test --override-config vibe-d:tls/openssl

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ brew install mongodb
 ```
 
 #### OpenSSL
-The project depens on OpenSSL being available. Both OpenSSL-1.0 and OpenSSL-1.1 are supported, but in order to successfully use OpenSSL-1.1, the switch `--override-config vibe-d:tls/openssl-1.1` needs to be added to all `dub` commands.
+The project depens on OpenSSL being available. Both OpenSSL-1.0 and OpenSSL-1.1 are supported, but in order to successfully use OpenSSL-1.0, the switch `--override-config vibe-d:tls/openssl` needs to be added to all `dub` commands.
 OpenSSL should be available by default on most systems. If it is not available, use your distribution’s packagemanager to install it if you are running linux, or [Homebrew](https://brew.sh/) if you are running OS X:
 - Debian based systems:
 ```

--- a/dub.json
+++ b/dub.json
@@ -6,9 +6,13 @@
 	"dependencies": {
 		"dauth": "~>0.6.3",
 		"mysql-native": "~>1.1.2",
-		"vibe-d": "~>0.8.1",
+		"vibe-d": "~>0.8.2",
+		"vibe-d:tls": "~>0.8.2",
 		"poodinis": "~>8.0.1"
 	},
+    "subConfigurations": {
+        "vibe-d:tls": "openssl-1.1"
+    },
 	"description": "A tool to manage the calendar of the Fachschaft Mathe/Physik Uni Regensburg ",
 	"copyright": "Copyright © 2018, Johannes Loher",
 	"license": "MIT",


### PR DESCRIPTION
As mentioned in #20 , this implements defaulting to OpenSSL-1.1 when compiling.

This includes the following changes:
 - Default to OpenSSL-1.1 when compiling
 - Update The `README.md` file to reflect this change
 - update vibe.d to 0.8.2
