### PR TITLE
Rework imports.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ Scope can be one of the following:
 - `technical` - everything else that is `technical` and does not belong to `test` or `refactor`
 - `chore` - everything not touching the actual code
 
-For the actual text in the commit message, here are some additional guideline:
+For the actual text in the commit message, here are some additional guidelines:
 
 - Use the present tense ("add feature" not "added feature").
 - Use the imperative mood ("move cursor to…" not "moves cursor to…").
@@ -117,6 +117,11 @@ For the actual text in the commit message, here are some additional guideline:
 
 ### D Styleguide
 All D code must adhere to [The D Style](https://dlang.org/dstyle.html). We suggest using [dfmt](https://github.com/dlang-community/dfmt) to format the code accordingly.
+
+### Imports
+
+All imports should be selective, except for module-level imports using more than three specific import. These should import the whole corresponding module.
+Each symbol should only be imported once, and with a scope as small as possible (i.e. function/scope level imports are preferred over module-level imports).
 
 ## Additional notes
 

--- a/source/fsicalmanagement/app.d
+++ b/source/fsicalmanagement/app.d
@@ -3,10 +3,9 @@ module fsicalmanagement.app;
 import fsicalmanagement.fsicalmanagement : FsicalManagement;
 import fsicalmanagement.configuration : Context;
 
-import poodinis;
+import poodinis : DependencyContainer, registerContext;
 
 import vibe.core.core : runApplication;
-import vibe.core.log : logInfo;
 
 import vibe.http.fileserver : serveStaticFiles;
 import vibe.http.router : URLRouter;

--- a/source/fsicalmanagement/authenticator.d
+++ b/source/fsicalmanagement/authenticator.d
@@ -2,7 +2,7 @@ module fsicalmanagement.authenticator;
 
 import fsicalmanagement.passhash : PasswordHasher;
 
-import poodinis;
+import poodinis : Autowire, DependencyContainer, Value;
 
 import std.conv : to;
 import std.range : InputRange;
@@ -87,7 +87,7 @@ enum Privilege
 class MySQLAuthenticator : Authenticator
 {
 private:
-    import mysql;
+    import mysql : MySQLPool, Row, prepare;
 
     @Autowire MySQLPool pool;
     @Autowire PasswordHasher passwordHasher;

--- a/source/fsicalmanagement/configuration.d
+++ b/source/fsicalmanagement/configuration.d
@@ -6,15 +6,15 @@ import vibe.db.mongo.collection : MongoCollection;
 
 class Context : ApplicationContext
 {
-private:
-    import fsicalmanagement.authenticator : Authenticator;
-    import fsicalmanagement.event : EventStore;
-    import fsicalmanagement.fsicalmanagement : FsicalManagement;
-    import fsicalmanagement.passhash : PasswordHasher, SHA256PasswordHasher;
-    import vibe.core.log : logInfo;
 public:
     override void registerDependencies(shared(DependencyContainer) container)
     {
+        import fsicalmanagement.authenticator : Authenticator;
+        import fsicalmanagement.event : EventStore;
+        import fsicalmanagement.fsicalmanagement : FsicalManagement;
+        import fsicalmanagement.passhash : PasswordHasher, SHA256PasswordHasher;
+        import vibe.core.log : logInfo;
+        
         container.register!(ValueInjector!Arguments, AppArgumentsInjector);
         auto arguments = container.resolve!(AppArgumentsInjector).get("");
         final switch (arguments.database) with (DatabaseArgument)

--- a/source/fsicalmanagement/configuration.d
+++ b/source/fsicalmanagement/configuration.d
@@ -1,17 +1,17 @@
 module fsicalmanagement.configuration;
 
-import fsicalmanagement.authenticator : Authenticator;
-import fsicalmanagement.fsicalmanagement : FsicalManagement;
-import fsicalmanagement.event : EventStore;
-import fsicalmanagement.passhash : PasswordHasher, SHA256PasswordHasher;
+public import poodinis;
 
-import poodinis;
-
-import vibe.core.log : logInfo;
 import vibe.db.mongo.collection : MongoCollection;
 
 class Context : ApplicationContext
 {
+private:
+    import fsicalmanagement.authenticator : Authenticator;
+    import fsicalmanagement.event : EventStore;
+    import fsicalmanagement.fsicalmanagement : FsicalManagement;
+    import fsicalmanagement.passhash : PasswordHasher, SHA256PasswordHasher;
+    import vibe.core.log : logInfo;
 public:
     override void registerDependencies(shared(DependencyContainer) container)
     {

--- a/source/fsicalmanagement/event.d
+++ b/source/fsicalmanagement/event.d
@@ -1,12 +1,11 @@
 module fsicalmanagement.event;
 
-import poodinis;
+import poodinis : Autowire, Value;
 
 import std.algorithm : map;
 import std.conv : to;
 import std.datetime : Date;
 import std.range.interfaces : InputRange, inputRangeObject;
-import std.typecons : Nullable;
 
 import vibe.data.bson : Bson, BsonObjectID, deserializeBson, serializeToBson;
 import vibe.data.serialization : serializationName = name;
@@ -71,7 +70,7 @@ private:
 class MySQLEventStore : EventStore
 {
 private:
-    import mysql;
+    import mysql : MySQLPool, prepare, Row;
 
     @Value("mysql.table.events") string eventsTableName;
 
@@ -103,7 +102,8 @@ public:
         scope (exit)
             cn.close;
         auto prepared = cn.prepare(
-                "INSERT INTO " ~ eventsTableName ~ " (begin, end, name, description, type, shout) VALUES(?, ?, ?, ?, ?, ?)");
+                "INSERT INTO " ~ eventsTableName ~ " (begin, end, name, description, type, shout)"
+                    ~ " VALUES(?, ?, ?, ?, ?, ?)");
         prepared.setArgs(event.begin, event.end, event.name, event.description,
                 event.type.to!uint, event.shout);
         prepared.exec();
@@ -155,6 +155,7 @@ enum EventType
 
 struct Event
 {
+    import std.typecons: Nullable;
     @serializationName("_id") string id;
     @serializationName("date") Date begin;
     @serializationName("end_date") Nullable!Date end;

--- a/source/fsicalmanagement/fsicalmanagement.d
+++ b/source/fsicalmanagement/fsicalmanagement.d
@@ -14,7 +14,7 @@ import std.typecons : Nullable;
 
 import vibe.http.server : HTTPServerRequest, HTTPServerResponse;
 import vibe.web.auth;
-import vibe.web.web : errorDisplay, noRoute, redirect, render, SessionVar, terminateSession;
+import vibe.web.web;
 
 @requiresAuth class FsicalManagement
 {

--- a/source/fsicalmanagement/fsicalmanagement.d
+++ b/source/fsicalmanagement/fsicalmanagement.d
@@ -1,28 +1,25 @@
 module fsicalmanagement.fsicalmanagement;
 
 import fsicalmanagement.authenticator;
-import fsicalmanagement.event;
+import fsicalmanagement.event : Event, EventStore, EventType;
 import fsicalmanagement.passhash : PasswordHasher;
 
 import core.time : days;
 
-import poodinis;
+import poodinis : Autowire;
 
 import std.datetime : Date;
 import std.exception : enforce;
 import std.typecons : Nullable;
 
-import vibe.data.bson : BsonObjectID;
-import vibe.http.common : HTTPStatusException;
 import vibe.http.server : HTTPServerRequest, HTTPServerResponse;
-import vibe.http.status : HTTPStatus;
 import vibe.web.auth;
-import vibe.web.web : errorDisplay, noRoute, redirect, render, SessionVar,
-    terminateSession;
+import vibe.web.web : errorDisplay, noRoute, redirect, render, SessionVar, terminateSession;
 
 @requiresAuth class FsicalManagement
 {
-    @noRoute AuthInfo authenticate(scope HTTPServerRequest req, scope HTTPServerResponse) @safe
+    import vibe.http.server : HTTPServerRequest;
+    @noRoute AuthInfo authenticate(scope HTTPServerRequest, scope HTTPServerResponse) @safe
     {
         if (authInfo.value.isNone)
             redirect("/login");

--- a/test/fsicalmanagement/testauthenticator.d
+++ b/test/fsicalmanagement/testauthenticator.d
@@ -1,14 +1,13 @@
 module test.fsicalmanagement.testauthenticator;
 
-import fsicalmanagement.authenticator;
-import fsicalmanagement.passhash : PasswordHasher, StubPasswordHasher;
+import fsicalmanagement.authenticator : AuthInfo, Privilege;
 
-import poodinis;
+import poodinis : ValueInjector;
 
-import unit_threaded.mock;
-import unit_threaded.should;
+import unit_threaded.mock : mock;
+import unit_threaded.should : shouldBeFalse, shouldBeTrue;
 
-import vibe.data.bson : Bson, BsonObjectID;
+import vibe.data.bson : Bson;
 
 interface Collection
 {
@@ -37,7 +36,11 @@ public:
 
 @("MongoDBAuthenticator.checkUser")
 @system unittest
-{
+{   
+    import fsicalmanagement.authenticator : Authenticator, MongoDBAuthenticator;
+    import fsicalmanagement.passhash : PasswordHasher, StubPasswordHasher;
+    import poodinis : DependencyContainer, RegistrationOption;
+
     auto collection = mock!Collection;
     auto container = new shared DependencyContainer;
     container.register!(ValueInjector!Collection, CollectionInjector);

--- a/test/fsicalmanagement/testevent.d
+++ b/test/fsicalmanagement/testevent.d
@@ -1,16 +1,16 @@
 module test.fsicalmanagement.testevent;
 
-import fsicalmanagement.event;
+// import fsicalmanagement.event;
 
-import poodinis;
+// import poodinis;
 
-import std.array;
-import std.algorithm : map;
+// import std.array;
+// import std.algorithm : map;
 
-import unit_threaded.mock;
-import unit_threaded.should;
+// import unit_threaded.mock;
+// import unit_threaded.should;
 
-import vibe.data.bson : Bson, serializeToBson;
+// import vibe.data.bson : Bson, serializeToBson;
 
 interface Collection
 {

--- a/test/fsicalmanagement/testevent.d
+++ b/test/fsicalmanagement/testevent.d
@@ -1,16 +1,13 @@
 module test.fsicalmanagement.testevent;
 
-// import fsicalmanagement.event;
+import fsicalmanagement.event : Event, EventStore, MongoDBEventStore;
 
-// import poodinis;
+import poodinis : DependencyContainer, RegistrationOption, ValueInjector;
 
-// import std.array;
-// import std.algorithm : map;
+import unit_threaded.mock : mock;
+import unit_threaded.should : shouldEqual, shouldThrowWithMessage;
 
-// import unit_threaded.mock;
-// import unit_threaded.should;
-
-// import vibe.data.bson : Bson, serializeToBson;
+import vibe.data.bson : Bson, serializeToBson;
 
 interface Collection
 {
@@ -143,6 +140,9 @@ public:
 @("MongoDBEventStore.getAllEvents")
 @system unittest
 {
+    import std.algorithm : map;
+    import std.array : array;
+
     auto collection = mock!Collection;
     auto container = new shared DependencyContainer;
     container.register!(ValueInjector!Collection, CollectionInjector);

--- a/test/fsicalmanagement/testpasshash.d
+++ b/test/fsicalmanagement/testpasshash.d
@@ -1,13 +1,14 @@
 module test.fsicalmanagement.testpasshash;
 
-import fsicalmanagement.passhash;
-
-import unit_threaded;
+import unit_threaded : getValue, Values;
+import unit_threaded.should : shouldBeTrue;
 
 @("StubPasswordHasher")
 @Values("", "test", "langesKompliziertesPasswort")
 @safe unittest
 {
+    import fsicalmanagement.passhash : StubPasswordHasher;
+
     immutable hasher = new StubPasswordHasher;
     immutable testPassword = getValue!string;
     hasher.checkHash(testPassword, hasher.generateHash(testPassword)).shouldBeTrue;
@@ -17,6 +18,8 @@ import unit_threaded;
 @Values("", "test", "langesKompliziertesPasswort")
 @safe unittest
 {
+    import fsicalmanagement.passhash : SHA256PasswordHasher;
+
     immutable hasher = new SHA256PasswordHasher;
     immutable testPassword = getValue!string;
     hasher.checkHash(testPassword, hasher.generateHash(testPassword)).shouldBeTrue;


### PR DESCRIPTION
As mentioned in #7, this cleans the imports.

This includes the following changes:
 - Make imports local where possible
 - Remove as many module imports as possible in favor of symbolic ones
 - Small style fixes

Still to do:
 - [X] Rework Application imports
 - [x] Rework test imports
 - [X] Is it sane to move imports in `configuration.d` to class-level of `Context`, or should they go to `Context.registerDependencies`? => *Put in method level*
 - [X] Is there an upper limit of symbolic imports per import on module level? (cf. `fsicalmanagement.d`, import of `vibe.web.web`) => *Take 3 as in acceptance criteria*
 - [x] Add imports directive to `Contributing.md`